### PR TITLE
Make log closer to Apache Combined Log Format definition

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,0 +1,26 @@
+# Golang CircleCI 2.0 configuration file
+#
+# Check https://circleci.com/docs/2.0/language-go/ for more details
+version: 2
+jobs:
+  build:
+    docker:
+      # specify the version
+      - image: circleci/golang:1.9
+
+      # Specify service dependencies here if necessary
+      # CircleCI maintains a library of pre-built images
+      # documented at https://circleci.com/docs/2.0/circleci-images/
+      # - image: circleci/postgres:9.4
+
+    #### TEMPLATE_NOTE: go expects specific checkout path representing url
+    #### expecting it in the form of
+    ####   /go/src/github.com/circleci/go-tool
+    ####   /go/src/bitbucket.org/circleci/go-tool
+    working_directory: /go/src/github.com/osunac/go-httplogger
+    steps:
+      - checkout
+
+      # specify any bash command here prefixed with `run: `
+      - run: go get -v -t -d ./...
+      - run: go test -v ./...

--- a/README.md
+++ b/README.md
@@ -30,3 +30,6 @@ Golang apache common log format middleware. It sits between in the topmost level
 	}
 
  
+### Example output
+
+	2018/12/31 12:20:33 HTTP - 127.0.0.1 - - [31/Dec/2018:12:20:33 +0100] "GET / HTTP/1.1" 200 12 "" "Wget/1.17.1 (linux-gnu)" 100351us

--- a/httplogger.go
+++ b/httplogger.go
@@ -2,8 +2,8 @@ package httplogger
 
 import (
 	"log"
+	"net"
 	"net/http"
-	"strings"
 	"time"
 )
 
@@ -43,9 +43,11 @@ func HTTPLogger(handler http.Handler) http.Handler {
 		t := time.Now()
 		interceptWriter := stResponseWriter{w, 0, 0}
 
+		host, _, _ := net.SplitHostPort(r.RemoteAddr)
+
 		handler.ServeHTTP(&interceptWriter, r)
 		log.Printf("HTTP - %s - - %s \"%s %s %s\" %d %d \"%s\" \"%s\" %dus\n",
-			strings.Split(r.RemoteAddr, ":")[0],
+			host,
 			t.Format("[02/Jan/2006:15:04:05 -0700]"),
 			r.Method,
 			r.URL.Path,

--- a/httplogger.go
+++ b/httplogger.go
@@ -3,6 +3,7 @@ package httplogger
 import (
 	"log"
 	"net/http"
+	"strings"
 	"time"
 )
 
@@ -43,16 +44,17 @@ func HTTPLogger(handler http.Handler) http.Handler {
 		interceptWriter := stResponseWriter{w, 0, 0}
 
 		handler.ServeHTTP(&interceptWriter, r)
-		log.Printf("HTTP - %s - - %s \"%s %s %s\" %d %d %s %dus\n",
-			r.RemoteAddr,
-			t.Format("02/Jan/2006:15:04:05 -0700"),
+		log.Printf("HTTP - %s - - %s \"%s %s %s\" %d %d \"%s\" \"%s\" %dus\n",
+			strings.Split(r.RemoteAddr, ":")[0],
+			t.Format("[02/Jan/2006:15:04:05 -0700]"),
 			r.Method,
 			r.URL.Path,
 			r.Proto,
 			interceptWriter.HTTPStatus,
 			interceptWriter.ResponseSize,
+			r.Referer(),
 			r.UserAgent(),
-			time.Since(t),
+			time.Since(t)/1000,
 		)
 	})
 }


### PR DESCRIPTION
Changes
=======

- fix client IP (no port)
- fix brackets around timestamp
- fix missing referer
- fix quotes around user agent
- fix duration unit (Go uses nanoseconds)


Validation
========

Test with [online Grok parser](http://grokconstructor.appspot.com/do/match) with log generated by the example application and the pattern `%{COMBINEDAPACHELOG}`. All the fields are extracted as expected.

Log format reference: https://httpd.apache.org/docs/1.3/logs.html